### PR TITLE
fix #9

### DIFF
--- a/cdrage-atomicapp-ci/atomic.sh
+++ b/cdrage-atomicapp-ci/atomic.sh
@@ -20,7 +20,7 @@ install_atomic() {
       cd atomic
     else
       wget $LINK -O atomic.tar.gz
-      tar -xvf atomic.tar.gz
+      tar --no-same-owner -xvf atomic.tar.gz
       cd atomic-$RELEASE
   fi
   


### PR DESCRIPTION
root does not try to preserve permissions when `--no-same-owner` is used. Helpful in case of SMB or NFS mounts.

More:

When extracting as root, tar will by default restore ownership of extracted files, unless --no-same-owner is used, which will give ownership to root himself.

References: http://serverfault.com/a/445504