### PR TITLE
Fix #11, implement nmap

### DIFF
--- a/cdrage-atomicapp-ci/providers/kubernetes.sh
+++ b/cdrage-atomicapp-ci/providers/kubernetes.sh
@@ -36,8 +36,9 @@ start_k8s() {
       --cluster-domain=cluster.local \
       --allow-privileged=true --v=2
 
-
-  until nc -z 127.0.0.1 8080;
+  until nmap -Pn 127.0.0.1 -p 8080 -oX - | \
+        xmllint --xpath '//port[@portid="8080"]/state/@state' - > \
+        /dev/null 2>&1;
   do
       echo ...
       sleep 1


### PR DESCRIPTION
Since `nc -z` is not being supported anymore, this can be implemented using `nmap`.

- `nmap -Pn ...` is scanning for the open ports
- `nmap ... -oX ...` outputs in XML format
- `xmllint ...` parses the XML output from `nmap` and shows shows the output of `state=` from
`
...
<ports><port protocol="tcp" portid="8080"><state state="open" reason="syn-ack" reason_ttl="64"/><service name="http-proxy" method="table" conf="3"/></port>
...
`

Then using the return value, the code proceeds.