### PR TITLE
Reorganization and Improves waiting for openshift containers to stop

### DIFF
--- a/cdrage-atomicapp-ci/etherpad.sh
+++ b/cdrage-atomicapp-ci/etherpad.sh
@@ -49,26 +49,10 @@ stop_etherpad() {
   # Remove Docker-provider-specific containers
   if [[ $1 == "docker" ]]; then
     docker rm -f mariadb-atomicapp-app etherpad-atomicapp etherpad || true
-
-  # Wait for k8s containers to finish terminating
-  # will change in the future to something in providers/kubernetes.sh
   elif [[ $1 == "kubernetes" ]]; then
-    echo "Waiting for k8s po/svc/rc to finish terminating..."
-    kubectl get po,svc,rc
-    sleep 3 # give kubectl chance to catch up to api call
-    while [ 1 ]
-    do
-      k8s=`kubectl get po,svc,rc | grep Terminating`
-      if [[ $k8s == "" ]]
-      then
-        echo "k8s po/svc/rc terminated!"
-        break
-      else
-        echo "..."
-      fi
-      sleep 1
-    done
-
+    ./providers/kubernetes.sh wait
+  elif [[ $1 == "openshift" ]]; then
+    ./providers/openshift.sh wait
   fi
 }
 

--- a/cdrage-atomicapp-ci/helloapache.sh
+++ b/cdrage-atomicapp-ci/helloapache.sh
@@ -28,24 +28,11 @@ stop_helloapache() {
     atomic stop projectatomic/helloapache -v build/
   fi
 
-  # Wait for k8s containers to finish terminating
-  # will change in the future to something in providers/kubernetes.sh
+  # Wait for k8s/oc containers to finish terminating
   if [[ $1 == "kubernetes" ]]; then
-    echo "Waiting for k8s po/svc/rc to finish terminating..."
-    kubectl get po,svc,rc
-    sleep 3 # give kubectl chance to catch up to api call
-    while [ 1 ]
-    do
-      k8s=`kubectl get po,svc,rc | grep Terminating`
-      if [[ $k8s == "" ]]
-      then
-        echo "k8s po/svc/rc terminated!"
-        break
-      else
-        echo "..."
-      fi
-      sleep 1
-    done
+    ./providers/kubernetes.sh wait
+  elif [[ $1 == "openshift" ]]; then
+    ./providers/openshift.sh wait
   fi
 }
 

--- a/cdrage-atomicapp-ci/providers/kubernetes.sh
+++ b/cdrage-atomicapp-ci/providers/kubernetes.sh
@@ -61,6 +61,24 @@ stop_k8s() {
   done
 }
 
+wait_k8s() {
+  echo "Waiting for k8s po/svc/rc to finish terminating..."
+  kubectl get po,svc,rc
+  sleep 3 # give kubectl chance to catch up to api call
+  while [ 1 ]
+  do
+    k8s=`kubectl get po,svc,rc | grep Terminating`
+    if [[ $k8s == "" ]]
+    then
+      echo "k8s po/svc/rc terminated!"
+      break
+    else
+      echo "..."
+    fi
+    sleep 1
+  done
+}
+
 answers_k8s() {
   echo "
   ##########
@@ -78,6 +96,8 @@ elif [[ $1 == "start" ]]; then
   start_k8s
 elif [[ $1 == "stop" ]]; then
   stop_k8s
+elif [[ $1 == "wait" ]]; then
+  wait_k8s
 else
-  echo $"Usage: kubernetes.sh {answers|start|stop}"
+  echo $"Usage: kubernetes.sh {answers|start|stop|wait}"
 fi

--- a/cdrage-atomicapp-ci/providers/openshift.sh
+++ b/cdrage-atomicapp-ci/providers/openshift.sh
@@ -74,12 +74,33 @@ answers_openshift() {
   echo "OpenShift Origin answers file located at $PWD"
 }
 
+# Use docker openshift container to get oc (assuming host doesn't have it)
+wait_openshift() {
+  echo "Waiting for oc po/svc/rc to finish terminating..."
+  docker exec -it origin oc get po,svc,rc
+  sleep 3 # give kubectl chance to catch up to api call
+  while [ 1 ]
+  do
+    oc=`docker exec -it origin oc get po,svc,rc | grep Terminating`
+    if [[ $oc == "" ]]
+    then
+      echo "oc po/svc/rc terminated!"
+      break
+    else
+      echo "..."
+    fi
+    sleep 1
+  done
+}
+
 if [[ $1 == "answers" ]]; then
   answers_openshift
 elif [[ $1 == "start" ]]; then
   start_openshift
 elif [[ $1 == "stop" ]]; then
   stop_openshift
+elif [[ $1 == "wait" ]]; then
+  wait_openshift 
 else
-  echo $"Usage: openshift.sh {answers|start|stop}"
+  echo $"Usage: openshift.sh {answers|start|stop|wait}"
 fi

--- a/cdrage-atomicapp-ci/wordpress.sh
+++ b/cdrage-atomicapp-ci/wordpress.sh
@@ -46,26 +46,10 @@ stop_wordpress() {
   # Remove Docker-provider-specific containers
   if [[ $1 == "docker" ]]; then
     docker rm -f mariadb-atomicapp-app wordpress-atomicapp wordpress || true
-
-  # Wait for k8s containers to finish terminating
-  # will change in the future to something in providers/kubernetes.sh
   elif [[ $1 == "kubernetes" ]]; then
-    echo "Waiting for k8s po/svc/rc to finish terminating..."
-    kubectl get po,svc,rc
-    sleep 3 # give kubectl chance to catch up to api call
-    while [ 1 ]
-    do
-      k8s=`kubectl get po,svc,rc | grep Terminating`
-      if [[ $k8s == "" ]]
-      then
-        echo "k8s po/svc/rc terminated!"
-        break
-      else
-        echo "..."
-      fi
-      sleep 1
-    done
-
+    ./providers/kubernetes.sh wait
+  elif [[ $1 == "openshift" ]]; then
+    ./providers/openshift.sh wait
   fi
 }
 


### PR DESCRIPTION
Adds a "wait" function to both kubernetes and openshift providers.

Add code to wait for all OpenShift instances to terminate before
proceeding with the next example.

Via using: `docker exec -it origin oc get po,svc,rc | grep Terminating`