### PR TITLE
Add jjb scripts for creating atomicapp unittest jobs.

### DIFF
--- a/cdrage-atomicapp-ci/centos-ci-jjb/project.yaml
+++ b/cdrage-atomicapp-ci/centos-ci-jjb/project.yaml
@@ -6,7 +6,8 @@
     name: centos-ci-bootstrap
     builders:
         - python:
-            !include-raw './run.py'
+            !include-raw:
+                - ./run.py
 
 # Custom Trigger. Sets up the Github pull request trigger
 # Accepts a parameter {provider}
@@ -26,7 +27,7 @@
               - kadel
             build-desc-template: "build description"
             trigger-phrase: '#dotests|#dotest{provider}'
-            only-trigger-phrase: true
+            only-trigger-phrase: {only-trigger-phrase}
             github-hooks: true
             permit-all: false
             auto-close-on-fail: false
@@ -64,22 +65,31 @@
           clean:
             after: true
           credentials-id: 1d7dba44-5b34-42b3-886c-4d659ffb2aae
+          refspec: "{refspec}"
+          branches:
+              - "{branch}"
 
 # job template for each provider to test against master
 - job-template:
     name: '{name}-{provider}-master'
     # restrict to nodes that are set up for atomicapp
     node: atomicapp-shared
+    properties:
+        - github:
+            url: "{git_repo_url}"
+    scm:
+        - custom-scm-git:
+            refspec: "{refspec}"
+            branch: "master"
     publishers:
         - custom-publisher-email
         - custom-publisher-irc
     builders:
         - inject:
             properties-content: |
-                #GIT_REPO_URL=https://github.com/dustymabe/adb-tests.git
-                GIT_REPO_URL=https://github.com/projectatomic/adb-tests.git
+                GIT_REPO_URL="{git_repo_url}"
                 MACHINE_COUNT=1
-                TEST_CMD='cd cdrage-atomicapp-ci/ && make install {provider} ATOMIC_SOURCE=rpm'
+                TEST_CMD='{test_cmd_master}'
         - centos-ci-bootstrap
 
 # job template for each provider to test PRs using GHPRB
@@ -89,10 +99,16 @@
     node: atomicapp-shared
     properties:
         - github:
-            url: https://github.com/projectatomic/atomicapp
+            url: "{git_repo_url}"
+    scm:
+        - custom-scm-git:
+            refspec: "{refspec}"
+            branch: "{branch}"
     triggers:
         - custom-trigger:
             provider: "{provider}"
+            only-trigger-phrase: {only-trigger-false}
+
     publishers:
         - custom-publisher-email
         - custom-publisher-irc
@@ -100,10 +116,9 @@
         - inject:
             properties-content: |
                 PROVIDER={provider}
-                #GIT_REPO_URL=https://github.com/dustymabe/adb-tests.git
-                GIT_REPO_URL=https://github.com/projectatomic/adb-tests.git
+                GIT_REPO_URL="{git_repo_url}"
                 MACHINE_COUNT=1
-                TEST_CMD='cd cdrage-atomicapp-ci/ && make install {provider} ATOMICAPP_PR=$ghprbPullId ATOMIC_SOURCE=rpm'
+                TEST_CMD = '{test_cmd}'
         - centos-ci-bootstrap
 
 # create the jobs using the job templates
@@ -113,6 +128,18 @@
         - docker
         - kubernetes
         - openshift
+        - unittest:
+            git_repo_url: "https://github.com/projectatomic/atomicapp"
+            refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+            branch: "${{sha1}}"
+            test_cmd_master: 'make test'
+            test_cmd: 'make test'
+    refspec: ""
+    branch: ""
+    only-trigger-phrase: true
+    git_repo_url: https://github.com/projectatomic/adb-tests.git
+    test_cmd: 'cd cdrage-atomicapp-ci/ && make install {provider} ATOMICAPP_PR=$ghprbPullId ATOMIC_SOURCE=rpm'
+    test_cmd_master: 'cd cdrage-atomicapp-ci/ && make install {provider} ATOMIC_SOURCE=rpm'
     jobs:
       - '{name}-{provider}-pr'
       - '{name}-{provider}-master'

--- a/cdrage-atomicapp-ci/centos-ci-jjb/run.py
+++ b/cdrage-atomicapp-ci/centos-ci-jjb/run.py
@@ -8,9 +8,11 @@ import json, urllib, subprocess, sys, os
 url_base = "http://admin.ci.centos.org:8080"
 api_key  = os.environ['CICO_API_KEY'] # comes from node environment vars
 count    = os.environ['MACHINE_COUNT']
+workspace = os.environ['WORKSPACE']
+provider = os.environ['PROVIDER']
 ver      = "7"
 arch     = "x86_64"
-req_url  = "%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api_key,ver,arch,count)
+req_url  = "%s/Node/get?key=%s&ver=%s&arch=%s&i_count=%s" % (url_base,api_key,ver,arch,count)
 
 # The git repo url of the project for us to clone
 git_repo_url = os.environ['GIT_REPO_URL']
@@ -22,8 +24,47 @@ jsondata = urllib.urlopen(req_url).read()
 # load into a dictionary
 data = json.loads(jsondata)
 
-# Iterate through the returned hosts and run the tests on it
-for host in data['hosts']:
+def run_unittest(host):
+    scp_cmd = "scp "
+    scp_cmd += "-o UserKnownHostsFile=/dev/null "
+    scp_cmd += "-o StrictHostKeyChecking=no -r "
+    scp_cmd += "%s root@%s:/tmp/test" % (workspace, host)
+
+    # Build the ssh part of the cmd to send
+    ssh_cmd  = "ssh -t -t " # Force psuedo tty allocation - need two -t
+    ssh_cmd += "-o UserKnownHostsFile=/dev/null " # Don't store host info
+    ssh_cmd += "-o StrictHostKeyChecking=no "     # Don't ask yes/no
+    ssh_cmd += "root@%s " % (host)                # Log in as root on the host
+
+    # Build up cmd to run on the remote duffy instance
+    #  - Install git
+    #  - Create and change to temporary directory
+    #  - Clone remote repo
+    #  - Finally run user specified test cmd
+    remote_cmd  = "cd /tmp/test && "
+    remote_cmd += 'yum install -y git epel-release && '
+    remote_cmd += 'yum install -y python-pip && '
+    remote_cmd += "pip install pytest-cov coveralls && "
+    remote_cmd += "pip install pep8 && "
+    remote_cmd += "pip install flake8 && "
+    remote_cmd += "make install && "
+    remote_cmd += "make syntax-check && "
+    remote_cmd += "bash -c %s " % test_cmd
+    
+    print "Copying checked out repository to host: {}".format(scp_cmd)
+    exit_code = subprocess.call(scp_cmd, shell=True)
+
+    cmd = '%s "%s"' % (ssh_cmd, remote_cmd)
+    print("Running cmd: {}".format(cmd))
+    exit_code = subprocess.call(cmd, shell=True)
+
+    # Send a rest request to release the node
+    done_nodes_url = "%s/Node/done?key=%s&ssid=%s" % (url_base, api_key, data['ssid'])
+    print urllib.urlopen(done_nodes_url).read()
+    return exit_code
+
+
+def run(host):
     # Build the ssh part of the cmd to send
     ssh_cmd  = "ssh -t -t " # Force psuedo tty allocation - need two -t
     ssh_cmd += "-o UserKnownHostsFile=/dev/null " # Don't store host info
@@ -47,4 +88,12 @@ for host in data['hosts']:
     # Send a rest request to release the node
     done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api_key, data['ssid'])
     print urllib.urlopen(done_nodes_url).read()
+    return exit_code
+
+# Iterate through the returned hosts and run the tests on it
+for host in data['hosts']:
+    if provider == 'unittest':
+        exit_code = run_unittest(host)
+    else:
+        exit_code = run(host)
 sys.exit(exit_code)


### PR DESCRIPTION
This modifies existing JJB scripts to add jobs for running unittests for atomicapp on ci.centos.org along with jobs for other providers: docker, kubernetes, openshift.