### PR TITLE
Modify OpenShift provider to new Atomic App params

### DIFF
--- a/cdrage-atomicapp-ci/functional-tests/providers/openshift.sh
+++ b/cdrage-atomicapp-ci/functional-tests/providers/openshift.sh
@@ -66,10 +66,10 @@ answers_openshift() {
 
   echo "[general]
   provider = openshift
-  providerapi = https://localhost:8443
-  accesstoken = $API_KEY 
+  provider-api = https://localhost:8443
+  provider-auth = $API_KEY 
   namespace = foo
-  providertlsverify = False" > answers.conf
+  provider-tlsverify = False" > answers.conf
 
   echo "OpenShift Origin answers file located at $PWD"
 }


### PR DESCRIPTION
This modifies the openshift answers.conf file to accomodate to the new
Atomic App CLI prams being added.

See: https://github.com/projectatomic/atomicapp/pull/685