### PR TITLE
Fail on patching

### DIFF
--- a/cdrage-atomicapp-ci/functional-tests/atomicapp.sh
+++ b/cdrage-atomicapp-ci/functional-tests/atomicapp.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 LINK="https://github.com/projectatomic/atomicapp"
 UPSTREAM="projectatomic/atomicapp"


### PR DESCRIPTION
Adds set -e so bash will automatically fail if anything in the
atomicapp.sh script fails.