### PR TITLE
atomicapp: remove workaround for atomic cli bug

### DIFF
--- a/cdrage-atomicapp-ci/functional-tests/etherpad.sh
+++ b/cdrage-atomicapp-ci/functional-tests/etherpad.sh
@@ -34,17 +34,7 @@ run_etherpad() {
 }
 
 stop_etherpad() {
-  # Workaround atomic cli bug prior to 1.8 so we must determine if the
-  # version of atomic cli is at least 1.8. Do this by comparing the
-  # atomic cli version with "1.8". If the lesser version is "1.8"
-  # then the version we are using is >= "1.8".
-  atomicversion=$(atomic --version)
-  lesserversion=$(echo -e "${atomicversion}\n1.8" | sort -V | head -n 1)
-  if [ "$lesserversion" != '1.8' ]; then
-    atomicapp stop -v --logtype=nocolor build/
-  else
-    atomic stop etherpad -v --logtype=nocolor build/
-  fi
+  atomic stop etherpad -v --logtype=nocolor build/
 
   # Remove Docker-provider-specific containers
   if [[ $1 == "docker" ]]; then

--- a/cdrage-atomicapp-ci/functional-tests/helloapache.sh
+++ b/cdrage-atomicapp-ci/functional-tests/helloapache.sh
@@ -16,17 +16,7 @@ run_helloapache() {
 }
 
 stop_helloapache() {
-  # Workaround atomic cli bug prior to 1.8 so we must determine if the
-  # version of atomic cli is at least 1.8. Do this by comparing the
-  # atomic cli version with "1.8". If the lesser version is "1.8"
-  # then the version we are using is >= "1.8".
-  atomicversion=$(atomic --version)
-  lesserversion=$(echo -e "${atomicversion}\n1.8" | sort -V | head -n 1)
-  if [ "$lesserversion" != '1.8' ]; then
-    atomicapp stop -v --logtype=nocolor build/
-  else
-    atomic stop projectatomic/helloapache -v --logtype=nocolor build/
-  fi
+  atomic stop projectatomic/helloapache -v --logtype=nocolor build/
 
   # Wait for k8s/oc containers to finish terminating
   if [[ $1 == "kubernetes" ]]; then

--- a/cdrage-atomicapp-ci/functional-tests/wordpress.sh
+++ b/cdrage-atomicapp-ci/functional-tests/wordpress.sh
@@ -31,17 +31,7 @@ run_wordpress() {
 }
 
 stop_wordpress() {
-  # Workaround atomic cli bug prior to 1.8 so we must determine if the
-  # version of atomic cli is at least 1.8. Do this by comparing the
-  # atomic cli version with "1.8". If the lesser version is "1.8"
-  # then the version we are using is >= "1.8".
-  atomicversion=$(atomic --version)
-  lesserversion=$(echo -e "${atomicversion}\n1.8" | sort -V | head -n 1)
-  if [ "$lesserversion" != '1.8' ]; then
-    atomicapp stop -v --logtype=nocolor build/
-  else
-    atomic stop wordpress -v --logtype=nocolor build/
-  fi
+  atomic stop wordpress -v --logtype=nocolor build/
 
   # Remove Docker-provider-specific containers
   if [[ $1 == "docker" ]]; then


### PR DESCRIPTION
Now that CentOS is up to Atomic CLI version 1.9 we can remove
the workaround we put in place.