### PR TITLE
Tests for Mesos provider to run before releasing new version of ADB

### DIFF
--- a/adb-vagrantfile-tests/adb-release-mesos/job.yaml
+++ b/adb-vagrantfile-tests/adb-release-mesos/job.yaml
@@ -1,0 +1,30 @@
+- job:
+    name: adb-release-mesos
+    node: atomic-sig
+    properties:
+        - github:
+            url: https://github.com/projectatomic/adb-atomic-developer-bundle
+    publishers:
+        - email:
+            recipients: dshah@redhat.com
+
+    parameters:
+        - string:
+            name: libvirtbox
+            default: http://cbs.centos.org/kojifiles/work/tasks/7015/87015/centos-7-adb-2.0-0.x86_64.rhevm.ova
+            description: Vagrant box for libvirt provider
+
+    builders:
+        - inject:
+            properties-content: |
+                MACHINE_COUNT=1
+                GIT_REPO_URL='https://github.com/dharmit/adb-tests.git'
+                ANSIBLE_REPO_URL='https://github.com/dharmit/adb-ci-ansible'
+                TEST_CMD=cd /root/adb-tests/adb-vagrantfile-tests && git checkout adb-release-mesos && cd adb-release-mesos && scl enable sclo-vagrant1 'bash -c "./test-new-build-mesos.py"'
+        - centos-ci-bootstrap
+
+- builder:
+    name: centos-ci-bootstrap
+    builders:
+        - python:
+            !include-raw: './run.py'

--- a/adb-vagrantfile-tests/adb-release-mesos/run.py
+++ b/adb-vagrantfile-tests/adb-release-mesos/run.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+
+import json
+import os
+import subprocess
+import sys
+import urllib
+
+
+url_base = "http://admin.ci.centos.org:8080"
+api_key = open("/home/atomic-sig/duffy.key").read().strip()
+count = os.environ['MACHINE_COUNT']
+ver = "7"
+arch = "x86_64"
+req_url = "%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" \
+    % (url_base, api_key, ver, arch, count)
+
+ansible_repo_url = os.environ['ANSIBLE_REPO_URL']
+
+libvirtbox = os.environ['libvirtbox']
+
+test_cmd = 'export libvirtbox=%s && ' % libvirtbox
+test_cmd += os.environ['TEST_CMD']
+
+# TODO - This needs to be removed before merging the PR
+tests_repo = 'https://github.com/dharmit/adb-tests'
+
+try:
+    jsondata = urllib.urlopen(req_url).read()
+except Exception as e:
+    print e.message()
+    sys.exit(1)
+
+data = json.loads(jsondata)
+
+for host in data['hosts']:
+    h = data['hosts'][0]
+
+    ssh_cmd = ("ssh -t -t "
+               "-o UserKnownHostsFile=/dev/null "
+               "-o StrictHostKeyChecking=no "
+               "root@%s " % (h))
+
+    # TODO - Before merge, git clone of `tests_repo` needs to be removed
+    remote_cmd = ("yum -y -q install git && "
+                  "git clone %s && "
+                  "git clone https://github.com/dharmit/adb-tests && "
+                  "cd adb-ci-ansible && ./install-ansible.sh && "
+                  "ansible-playbook install-adb.yml --extra-vars "
+                  "'clone_adb_repo=true pull_adb_libvirt_box=false'") % \
+        (ansible_repo_url)
+
+    # This `cmd` does all the installation and setup
+    cmd = '%s "%s"' % (ssh_cmd, remote_cmd)
+
+    print("Running cmd: {}".format(cmd))
+    exit_code = subprocess.call(cmd, shell=True)
+
+    # This `cmd` does all the tests
+    cmd = '%s "%s"' % (ssh_cmd, test_cmd)
+
+    print("Running cmd: {}".format(cmd))
+    exit_code = subprocess.call(cmd, shell=True)
+
+    done_nodes_url = "%s/Node/done?key=%s&ssid=%s" % (url_base, api_key,
+                                                      data['ssid'])
+    print urllib.urlopen(done_nodes_url).read()
+sys.exit(exit_code)

--- a/adb-vagrantfile-tests/adb-release-mesos/test-new-build-mesos.py
+++ b/adb-vagrantfile-tests/adb-release-mesos/test-new-build-mesos.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+
+import os
+import sys
+import unittest
+import subprocess
+
+from unittest import TestCase
+
+VAGRANTFILE_PATH = \
+    "/root/adb/components/centos/centos-mesos-marathon-singlenode-setup/" \
+    "Vagrantfile"
+
+CWD = "/root/adb/components/centos/centos-mesos-marathon-singlenode-setup/"
+
+
+class MesosTests(TestCase):
+
+    """This class tests for Mesos provider on ADB box"""
+
+    def test_01_pull_Vagrant_box(self):
+        try:
+            exit_code = subprocess.check_call(
+                ['vagrant', 'box', 'add', '--name', 'adb-latest',
+                 '%s' % os.environ['libvirtbox']]
+            )
+        except:
+            sys.exit(1)
+        self.assertEqual(exit_code, 0)
+
+    def test_02_VagrantUp(self):
+        try:
+            # Vagrantfile would boot projectatomic/adb. We need to modify this
+            # to use the latest box (adb-latest) that's supposed to be
+            # released. Hence using sed
+            with open(VAGRANTFILE_PATH) as f:
+                filedata = f.read()
+
+            newdata = filedata.replace("projectatomic/adb", "adb-latest")
+
+            with open(VAGRANTFILE_PATH, "w") as f:
+                f.write(newdata)
+
+            exit_code = subprocess.check_call(
+                ['vagrant', 'up'],
+                cwd=CWD
+            )
+        except:
+            sys.exit(1)
+        self.assertEqual(exit_code, 0)
+
+    def test_03_check_services_status(self):
+        services = {
+            "zookeeper": "",
+            "marathon": "",
+            "mesos-master": "",
+            "mesos-slave": ""
+        }
+        for s in services:
+            try:
+                cmd = "systemctl is-active %s" % s
+                out = subprocess.check_output(
+                    ['vagrant', 'ssh', '-c', '%s' % cmd],
+                    cwd=CWD
+                    )
+                services[s] = out.strip()
+            except:
+                pass
+        for s in services:
+            self.assertEqual(services[s], 'active')
+
+    def test_04_start_atomicapp(self):
+        setup_atomicapp = "sudo yum -y install atomicapp"
+
+        start_helloapache = \
+            "sudo atomicapp run --provider=marathon projectatomic/helloapache"
+
+        api_request = \
+            "curl localhost:8080/v2/apps/helloapache"
+        try:
+            subprocess.check_call(
+                ['vagrant', 'ssh', '-c', '%s' % setup_atomicapp],
+                cwd=CWD
+            )
+            subprocess.check_call(
+                ['vagrant', 'ssh', '-c', '%s' % start_helloapache],
+                cwd=CWD
+            )
+
+            out = subprocess.check_output(
+                ['vagrant', 'ssh', '-c', '%s' % api_request],
+                cwd=CWD
+            )
+
+        except:
+            pass
+
+        self.assertIn('"appId":"/helloapache"', out)
+
+    def test_05_VagrantDestroy(self):
+        """Check force destroy vagrant box."""
+        try:
+            exit_code = subprocess.check_call(
+                ['vagrant', 'destroy', '-f'],
+                cwd=CWD
+            )
+        except:
+            pass
+        self.assertEqual(exit_code, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This job can be accessed on [CentOS CI UI](https://ci.centos.org/job/adb-release-mesos/). 

This is a parameterized build which asks for a URL before starting the build. The URL needs to be a valid URL to the Vagrant box. Once you provide a valid URL, flow of the job is like below:
1. New Vagrant box is pulled for `libvirt` provider.
2. [Atomic Developer Bundle repo](https://github.com/projectatomic/adb-atomic-developer-bundle/) is cloned to `~/adb`.
3. My fork of **ADB Tests** repo is cloned to `~/adb-tests`.
4. Vagrantfile for Mesos provider under `~/adb/components/centos/centos-mesos-marathon-singlenode-setup/` is modified to refer to the newly built box instead of default `projectatomic/adb`. 
5. New Vagrant box is boot up.
6. We clone [atomicapp](https://github.com/projectatomic/atomicapp) inside the box, start an atomicapp `projectatomic/helloapache` with the provider Mesos and hit Marathon API to check if the app started up properly.
7. Vagrant box is destroyed before exiting the tests.

@navidshaikh ping, once again we need to remove references to my fork before the final merge.
